### PR TITLE
Minor Corrections in i2c_read_register

### DIFF
--- a/I2C.c
+++ b/I2C.c
@@ -146,7 +146,7 @@ int i2c_read_register(int fd, unsigned char read_addr, unsigned char *read_data)
 		perror("I2C: Failed to write |");
 		return -1;
 	}
-	ret = read(fd, &read_data, I2C_ONE_BYTE);
+	ret = read(fd, read_data, I2C_ONE_BYTE);
 	if(ret == -1)
 		perror("I2C: Failed to read |");
 	if(ret == 0)


### PR DESCRIPTION
It is necessary to change line 149: ret = read(fd, &read_data, I2C_ONE_BYTE); to ret = read(fd, read_data, I2C_ONE_BYTE); in order to make this function work because read_data is already a pointer.